### PR TITLE
fix: migrate to go-common v0.22.0 for cli

### DIFF
--- a/cmd/api_token.go
+++ b/cmd/api_token.go
@@ -24,8 +24,9 @@ func apiTokenCmd(ac *ic.Context) *cobra.Command {
 
 type apiTokenOptions struct{}
 
-func (o *apiTokenOptions) Complete(_ context.Context, _ *ic.Context) error { return nil }
-func (o *apiTokenOptions) Validate(_ context.Context, _ *ic.Context) error { return nil }
+func (o *apiTokenOptions) SetupFlags(_ context.Context, _ *ic.Context) error { return nil }
+func (o *apiTokenOptions) Complete(_ context.Context, _ *ic.Context) error   { return nil }
+func (o *apiTokenOptions) Validate(_ context.Context, _ *ic.Context) error   { return nil }
 func (o *apiTokenOptions) Run(ctx context.Context, ac *ic.Context) error {
 	logger := ac.EC.Logger.WithGroup("Login")
 	ac.Authenticator.SetLogger(logger)

--- a/cmd/create_cluster.go
+++ b/cmd/create_cluster.go
@@ -13,7 +13,6 @@ import (
 	"github.com/neticdk/go-common/pkg/cli/ui"
 	"github.com/neticdk/go-common/pkg/types"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 func createClusterCmd(ac *ic.Context) *cobra.Command {
@@ -23,14 +22,6 @@ func createClusterCmd(ac *ic.Context) *cobra.Command {
 		WithGroupID(groupCluster).
 		Build()
 
-	o.bindFlags(c.Flags())
-	c.Flags().SortFlags = false
-	c.MarkFlagRequired("name")            //nolint:errcheck
-	c.MarkFlagRequired("provider")        //nolint:errcheck
-	c.MarkFlagRequired("environment")     //nolint:errcheck
-	c.MarkFlagRequired("subscription")    //nolint:errcheck
-	c.MarkFlagRequired("resilience-zone") //nolint:errcheck
-	c.MarkFlagsRequiredTogether("has-co", "co-url")
 	return c
 }
 
@@ -52,7 +43,10 @@ type createClusterOptions struct {
 	CustomOperationsURL      string
 }
 
-func (o *createClusterOptions) bindFlags(f *pflag.FlagSet) {
+func (o *createClusterOptions) SetupFlags(_ context.Context, ac *ic.Context) error {
+	c := ac.EC.Command
+	f := c.Flags()
+
 	f.StringVar(&o.Name, "name", "", "Cluster name")
 	f.StringVar(&o.ProviderName, "provider", "", "Provider Name")
 	f.StringVar(&o.Description, "description", "", "Cluster Description")
@@ -68,6 +62,16 @@ func (o *createClusterOptions) bindFlags(f *pflag.FlagSet) {
 	f.BoolVar(&o.HasApplicationManagement, "has-am", false, "Application Management")
 	f.BoolVar(&o.HasCustomOperations, "has-co", false, "Custom Operations")
 	f.StringVar(&o.CustomOperationsURL, "co-url", "", "Custom Operations URL")
+
+	c.Flags().SortFlags = false
+	c.MarkFlagRequired("name")            //nolint:errcheck
+	c.MarkFlagRequired("provider")        //nolint:errcheck
+	c.MarkFlagRequired("environment")     //nolint:errcheck
+	c.MarkFlagRequired("subscription")    //nolint:errcheck
+	c.MarkFlagRequired("resilience-zone") //nolint:errcheck
+	c.MarkFlagsRequiredTogether("has-co", "co-url")
+
+	return nil
 }
 
 func (o *createClusterOptions) Complete(_ context.Context, _ *ic.Context) error {

--- a/cmd/create_cluster_test.go
+++ b/cmd/create_cluster_test.go
@@ -244,10 +244,15 @@ func Test_CreateClusterCommandServiceLevels(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			ac, _ := newMockedCreateClusterEC(t)
 			command := newRootCmd(ac)
-			command.SetArgs(tc.args)
+			ac.EC.Command = command // Reassign, since the last subcommand is the command of the execution context
 			o := &createClusterOptions{}
-			o.bindFlags(command.Flags())
-			err := command.ParseFlags(tc.args)
+			err := o.SetupFlags(t.Context(), ac)
+			if err != nil {
+				t.Log(err)
+			}
+			assert.NoError(t, err)
+			command.SetArgs(tc.args)
+			err = command.ParseFlags(tc.args)
 			if err != nil {
 				t.Log(err)
 			}

--- a/cmd/delete_cluster.go
+++ b/cmd/delete_cluster.go
@@ -28,6 +28,7 @@ type deleteClusterOptions struct {
 	clusterID string
 }
 
+func (o *deleteClusterOptions) SetupFlags(_ context.Context, _ *ic.Context) error { return nil }
 func (o *deleteClusterOptions) Complete(_ context.Context, ac *ic.Context) error {
 	o.clusterID = ac.EC.CommandArgs[0]
 	return nil

--- a/cmd/get_cluster.go
+++ b/cmd/get_cluster.go
@@ -27,6 +27,7 @@ type getClusterOptions struct {
 	clusterID string
 }
 
+func (o *getClusterOptions) SetupFlags(_ context.Context, _ *ic.Context) error { return nil }
 func (o *getClusterOptions) Complete(_ context.Context, ac *ic.Context) error {
 	o.clusterID = ac.EC.CommandArgs[0]
 	return nil

--- a/cmd/get_cluster_kubeconfig.go
+++ b/cmd/get_cluster_kubeconfig.go
@@ -9,7 +9,6 @@ import (
 	"github.com/neticdk/go-common/pkg/cli/cmd"
 	"github.com/neticdk/go-common/pkg/cli/ui"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 const getClusterKubeConfigExample = `
@@ -25,8 +24,6 @@ func getClusterKubeconfigCmd(ac *ic.Context) *cobra.Command {
 		Build()
 	c.Aliases = []string{"kubeconfig"}
 
-	o.bindFlags(c.Flags())
-	c.MarkFlagsOneRequired("cluster-name", "cluster-id") //nolint:errcheck
 	return c
 }
 
@@ -35,9 +32,15 @@ type getClusterKubeConfigOptions struct {
 	clusterName string
 }
 
-func (o *getClusterKubeConfigOptions) bindFlags(f *pflag.FlagSet) {
+func (o *getClusterKubeConfigOptions) SetupFlags(_ context.Context, ac *ic.Context) error {
+	c := ac.EC.Command
+	f := c.Flags()
+
 	f.StringVar(&o.clusterID, "cluster-id", "", "The id of the cluster")
 	f.StringVar(&o.clusterName, "cluster-name", "", "The id of the cluster. Use cluster-id instead")
+
+	c.MarkFlagsOneRequired("cluster-name", "cluster-id")
+	return nil
 }
 
 func (o *getClusterKubeConfigOptions) Complete(_ context.Context, _ *ic.Context) error { return nil }

--- a/cmd/get_cluster_node.go
+++ b/cmd/get_cluster_node.go
@@ -8,7 +8,6 @@ import (
 	"github.com/neticdk/go-common/pkg/cli/cmd"
 	"github.com/neticdk/go-common/pkg/cli/ui"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 const getClusterNodeExample = `
@@ -24,9 +23,6 @@ func getClusterNodeCmd(ac *ic.Context) *cobra.Command {
 		Build()
 	c.Aliases = []string{"node"}
 
-	o.bindFlags(c.Flags())
-	c.MarkFlagRequired("cluster-name") //nolint:errcheck
-	c.MarkFlagRequired("node-name")    //nolint:errcheck
 	return c
 }
 
@@ -35,9 +31,17 @@ type getClusterNodeOptions struct {
 	nodeName    string
 }
 
-func (o *getClusterNodeOptions) bindFlags(f *pflag.FlagSet) {
+func (o *getClusterNodeOptions) SetupFlags(_ context.Context, ac *ic.Context) error {
+	c := ac.EC.Command
+	f := c.Flags()
+
 	f.StringVar(&o.clusterName, "cluster-name", "", "The name of the cluster")
 	f.StringVar(&o.nodeName, "node-name", "", "The name of the node")
+
+	c.MarkFlagRequired("cluster-name") //nolint:errcheck
+	c.MarkFlagRequired("node-name")    //nolint:errcheck
+
+	return nil
 }
 
 func (o *getClusterNodeOptions) Complete(_ context.Context, _ *ic.Context) error { return nil }

--- a/cmd/get_cluster_nodes.go
+++ b/cmd/get_cluster_nodes.go
@@ -9,7 +9,6 @@ import (
 	"github.com/neticdk/go-common/pkg/cli/ui"
 	"github.com/neticdk/go-common/pkg/qsparser"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 const getClusterNodesLongDesc = `Get list of nodes for a nodes.
@@ -37,8 +36,6 @@ func getClusterNodesCmd(ac *ic.Context) *cobra.Command {
 		Build()
 	c.Aliases = []string{"nodes"}
 
-	o.bindFlags(c.Flags())
-	c.MarkFlagRequired("cluster-name") //nolint:errcheck
 	return c
 }
 
@@ -58,9 +55,16 @@ type getClusterNodesOptions struct {
 	Filters []string
 }
 
-func (o *getClusterNodesOptions) bindFlags(f *pflag.FlagSet) {
+func (o *getClusterNodesOptions) SetupFlags(_ context.Context, ac *ic.Context) error {
+	c := ac.EC.Command
+	f := c.Flags()
+
 	f.StringVar(&o.clusterName, "cluster-name", "", "The name of the cluster")
 	f.StringArrayVar(&o.Filters, "filter", []string{}, "Filter output based on conditions")
+
+	c.MarkFlagRequired("cluster-name") //nolint:errcheck
+
+	return nil
 }
 
 func (o *getClusterNodesOptions) Complete(_ context.Context, _ *ic.Context) error { return nil }

--- a/cmd/get_clusters.go
+++ b/cmd/get_clusters.go
@@ -13,7 +13,6 @@ import (
 	"github.com/neticdk/go-common/pkg/cli/ui"
 	"github.com/neticdk/go-common/pkg/qsparser"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 const PerPage = 50
@@ -52,7 +51,6 @@ func getClustersCmd(ac *ic.Context) *cobra.Command {
 		WithGroupID(groupCluster).
 		Build()
 
-	o.bindFlags(c.Flags())
 	return c
 }
 
@@ -71,8 +69,12 @@ type getClustersOptions struct {
 	Filters []string
 }
 
-func (o *getClustersOptions) bindFlags(f *pflag.FlagSet) {
+func (o *getClustersOptions) SetupFlags(_ context.Context, ac *ic.Context) error {
+	c := ac.EC.Command
+	f := c.Flags()
+
 	f.StringArrayVar(&o.Filters, "filter", []string{}, "Filter output based on conditions")
+	return nil
 }
 
 func (o *getClustersOptions) Complete(_ context.Context, _ *ic.Context) error { return nil }

--- a/cmd/get_component.go
+++ b/cmd/get_component.go
@@ -28,6 +28,7 @@ type getComponentOptions struct {
 	component string
 }
 
+func (o *getComponentOptions) SetupFlags(_ context.Context, _ *ic.Context) error { return nil }
 func (o *getComponentOptions) Complete(_ context.Context, ac *ic.Context) error {
 	o.namespace = ac.EC.CommandArgs[0]
 	o.component = ac.EC.CommandArgs[1]

--- a/cmd/get_components.go
+++ b/cmd/get_components.go
@@ -8,7 +8,6 @@ import (
 	"github.com/neticdk/go-common/pkg/cli/cmd"
 	"github.com/neticdk/go-common/pkg/cli/ui"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 func getComponentsCmd(ac *ic.Context) *cobra.Command {
@@ -18,16 +17,14 @@ func getComponentsCmd(ac *ic.Context) *cobra.Command {
 		WithGroupID(groupComponent).
 		Build()
 
-	o.bindFlags(c.Flags())
 	return c
 }
 
 type getComponentsOptions struct{}
 
-func (o *getComponentsOptions) bindFlags(_ *pflag.FlagSet) {}
-
-func (o *getComponentsOptions) Complete(_ context.Context, _ *ic.Context) error { return nil }
-func (o *getComponentsOptions) Validate(_ context.Context, _ *ic.Context) error { return nil }
+func (o *getComponentsOptions) SetupFlags(_ context.Context, _ *ic.Context) error { return nil }
+func (o *getComponentsOptions) Complete(_ context.Context, _ *ic.Context) error   { return nil }
+func (o *getComponentsOptions) Validate(_ context.Context, _ *ic.Context) error   { return nil }
 
 func (o *getComponentsOptions) Run(ctx context.Context, ac *ic.Context) error {
 	logger := ac.EC.Logger.WithGroup("Components")

--- a/cmd/get_partitions.go
+++ b/cmd/get_partitions.go
@@ -21,8 +21,9 @@ func getPartitionsCmd(ac *ic.Context) *cobra.Command {
 
 type getPartitionsOptions struct{}
 
-func (o *getPartitionsOptions) Complete(_ context.Context, _ *ic.Context) error { return nil }
-func (o *getPartitionsOptions) Validate(_ context.Context, _ *ic.Context) error { return nil }
+func (o *getPartitionsOptions) SetupFlags(_ context.Context, _ *ic.Context) error { return nil }
+func (o *getPartitionsOptions) Complete(_ context.Context, _ *ic.Context) error   { return nil }
+func (o *getPartitionsOptions) Validate(_ context.Context, _ *ic.Context) error   { return nil }
 
 func (o *getPartitionsOptions) Run(_ context.Context, ac *ic.Context) error {
 	partitions := partition.ListPartitions()

--- a/cmd/get_regions.go
+++ b/cmd/get_regions.go
@@ -10,7 +10,6 @@ import (
 	"github.com/neticdk/go-common/pkg/cli/cmd"
 	"github.com/neticdk/go-common/pkg/types"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 func getRegionsCmd(ac *ic.Context) *cobra.Command {
@@ -20,7 +19,6 @@ func getRegionsCmd(ac *ic.Context) *cobra.Command {
 		WithGroupID(groupOther).
 		Build()
 
-	o.bindFlags(c.Flags())
 	return c
 }
 
@@ -28,8 +26,12 @@ type getRegionsOptions struct {
 	Partition string
 }
 
-func (o *getRegionsOptions) bindFlags(f *pflag.FlagSet) {
+func (o *getRegionsOptions) SetupFlags(_ context.Context, ac *ic.Context) error {
+	c := ac.EC.Command
+	f := c.Flags()
+
 	f.StringVar(&o.Partition, "partition", "", fmt.Sprintf("Partition. One of (%s)", strings.Join(types.AllPartitionsString(), "|")))
+	return nil
 }
 
 func (o *getRegionsOptions) Complete(_ context.Context, _ *ic.Context) error { return nil }

--- a/cmd/get_resilience_zones.go
+++ b/cmd/get_resilience_zones.go
@@ -21,8 +21,9 @@ func getResilienceZonesCmd(ac *ic.Context) *cobra.Command {
 
 type getResilienceZonesOptions struct{}
 
-func (o *getResilienceZonesOptions) Complete(_ context.Context, _ *ic.Context) error { return nil }
-func (o *getResilienceZonesOptions) Validate(_ context.Context, _ *ic.Context) error { return nil }
+func (o *getResilienceZonesOptions) SetupFlags(_ context.Context, _ *ic.Context) error { return nil }
+func (o *getResilienceZonesOptions) Complete(_ context.Context, _ *ic.Context) error   { return nil }
+func (o *getResilienceZonesOptions) Validate(_ context.Context, _ *ic.Context) error   { return nil }
 
 func (o *getResilienceZonesOptions) Run(_ context.Context, ac *ic.Context) error {
 	rzs := resiliencezone.ListResilienceZones()

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -28,8 +28,9 @@ func loginCmd(ac *ic.Context) *cobra.Command {
 
 type loginOptions struct{}
 
-func (o *loginOptions) Complete(_ context.Context, _ *ic.Context) error { return nil }
-func (o *loginOptions) Validate(_ context.Context, _ *ic.Context) error { return nil }
+func (o *loginOptions) SetupFlags(_ context.Context, _ *ic.Context) error { return nil }
+func (o *loginOptions) Complete(_ context.Context, _ *ic.Context) error   { return nil }
+func (o *loginOptions) Validate(_ context.Context, _ *ic.Context) error   { return nil }
 func (o *loginOptions) Run(ctx context.Context, ac *ic.Context) error {
 	logger := ac.EC.Logger.WithGroup("Login")
 	ac.Authenticator.SetLogger(logger)

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -17,12 +17,18 @@ func logoutCmd(ac *ic.Context) *cobra.Command {
 		WithGroupID(groupAuth).
 		Build()
 
-	c.Flags().SortFlags = false
 	return c
 }
 
 type logoutOptions struct{}
 
+func (o *logoutOptions) SetupFlags(_ context.Context, ac *ic.Context) error {
+	c := ac.EC.Command
+	f := c.Flags()
+
+	f.SortFlags = false
+	return nil
+}
 func (o *logoutOptions) Complete(_ context.Context, _ *ic.Context) error { return nil }
 func (o *logoutOptions) Validate(_ context.Context, _ *ic.Context) error { return nil }
 

--- a/cmd/update_cluster.go
+++ b/cmd/update_cluster.go
@@ -13,7 +13,6 @@ import (
 	"github.com/neticdk/go-common/pkg/cli/ui"
 	"github.com/neticdk/go-common/pkg/types"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 // New creates a new "update cluster" command
@@ -26,10 +25,6 @@ func updateClusterCmd(ac *ic.Context) *cobra.Command {
 		Build()
 	c.Use = "cluster CLUSTER-ID" //nolint:goconst
 
-	o.bindFlags(c.Flags())
-	c.Flags().SortFlags = false
-	c.MarkFlagsRequiredTogether("has-co", "co-url")
-	c.MarkFlagsOneRequired("description", "environment", "subscription", "infrastructure-provider", "resilience-zone", "has-to", "has-tm", "has-ao", "has-am", "has-co")
 	return c
 }
 
@@ -48,7 +43,10 @@ type updateClusterOptions struct {
 	CustomOperationsURL      string
 }
 
-func (o *updateClusterOptions) bindFlags(f *pflag.FlagSet) {
+func (o *updateClusterOptions) SetupFlags(_ context.Context, ac *ic.Context) error {
+	c := ac.EC.Command
+	f := c.Flags()
+
 	f.StringVar(&o.Description, "description", "", "Cluster Description")
 	f.StringVar(&o.EnvironmentName, "environment", "", "Environment Name")
 	f.StringVar(&o.SubscriptionID, "subscription", "", "Subscription ID")
@@ -60,6 +58,11 @@ func (o *updateClusterOptions) bindFlags(f *pflag.FlagSet) {
 	f.BoolVar(&o.HasApplicationManagement, "has-am", false, "Application Management")
 	f.BoolVar(&o.HasCustomOperations, "has-co", false, "Custom Operations")
 	f.StringVar(&o.CustomOperationsURL, "co-url", "", "Custom Operations URL")
+
+	f.SortFlags = false
+	c.MarkFlagsRequiredTogether("has-co", "co-url")
+	c.MarkFlagsOneRequired("description", "environment", "subscription", "infrastructure-provider", "resilience-zone", "has-to", "has-tm", "has-ao", "has-am", "has-co")
+	return nil
 }
 
 func (o *updateClusterOptions) Complete(_ context.Context, ac *ic.Context) error {

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
-	github.com/neticdk/go-stdlib v1.0.0 // indirect
+	github.com/neticdk/go-stdlib v0.2.1 // indirect
 	github.com/oapi-codegen/oapi-codegen/v2 v2.4.1 // indirect
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/neticdk-k8s/ic
 
-go 1.24.3
+go 1.24.4
 
 require (
 	github.com/coreos/go-oidc/v3 v3.14.1

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/neticdk/go-common v0.23.0 h1:p8SOl44BG5R7LRuhB/UBk+Lc67O1PTNCk/8HUWlXJAQ=
 github.com/neticdk/go-common v0.23.0/go.mod h1:t/5W1RF+1hJgbfon+LBkr8Q3cMxa5f4ytc7cwCto0/s=
-github.com/neticdk/go-stdlib v1.0.0 h1:9QCpoMpO5dBJGHJhumZrHzfJyvpVBd2Gc7ODJujfpXY=
-github.com/neticdk/go-stdlib v1.0.0/go.mod h1:rch+DEB6VtR972ZPTY6A5OyLmCrp2YlXP0WGjuDDdcw=
+github.com/neticdk/go-stdlib v0.2.1 h1:tUxYvWH4l8j+4WG9jcn/QuU+9T/IB3WUUoRK4ZqlN5s=
+github.com/neticdk/go-stdlib v0.2.1/go.mod h1:Av42pL+G/2EnCPZVF6WsJnCvvUXhkVpNDZp1YqY2ZTM=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=


### PR DESCRIPTION
Fixes the currently broken build by migrating the cli to go-common v0.22.0 which contains breaking changes